### PR TITLE
fix: decoding keys dead lock when OIDC running discovery

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -121,8 +121,10 @@ pub(crate) async fn process_request<R: Role>(
     let header = raw_token.decode_header()?;
 
     // First decode. This may fail if known decoding keys are out of date (Keycloak server changed).
-    let decoding_keys = kc_instance.decoding_keys().await;
-    let mut raw_claims = raw_token.decode(&header, expected_audiences, decoding_keys.iter());
+    let mut raw_claims = {
+        let decoding_keys = kc_instance.decoding_keys().await;
+        raw_token.decode(&header, expected_audiences, decoding_keys.iter())
+    };
 
     if raw_claims.is_err() {
         // Reload decoding keys. This may delay handling of the request in flight by a substantial amount of time


### PR DESCRIPTION
`decoding_keys()` contains a [read lock](https://github.com/lpotthast/axum-keycloak-auth/blob/f5bf7e023919c6ae20a657874bd43267c706d0d6/src/instance.rs#L138-L144) to `KeycloakAuthInstance discovory.value`, which cause dead lock when executing OIDC discovery.

This deadlock cause all services guarded by keyclock instance stuck forever. It can be easily reproduced with the example in docs, just by passing a token that triggers an OIDC discovery. We can try this token, which comes from a local dev keycloak server: 
```bash 
curl http://localhost:8081/protected -H "Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIteXh6aGRVbUZDTE1WcG9VN0cwdE41X0JWLUtua0RCTlgtNExENG1uQnBJIn0.eyJleHAiOjE3MDY2MDAxMTcsImlhdCI6MTcwNjU5OTgxNywiYXV0aF90aW1lIjoxNzA2NTk5ODExLCJqdGkiOiJjNmNjY2NmOS01NzA4LTQxNzktYjZhOS0yOTNiZDhmNTE3M2MiLCJpc3MiOiJodHRwOi8vMTI3LjAuMC4xOjgwODAvcmVhbG1zL3N2ZWx0ZS10ZXN0IiwiYXVkIjoiYWNjb3VudCIsInN1YiI6IjYyYzBkNDExLWY4YzktNDRiYi04MmUzLWU3YTBjNmRjNDg2OSIsInR5cCI6IkJlYXJlciIsImF6cCI6InN2ZWx0ZS10ZXN0Iiwibm9uY2UiOiI3YTc4Zjc4ZC0yNzIwLTQ4NTMtYmRlZi1jYWI0NGJhNDk4MTgiLCJzZXNzaW9uX3N0YXRlIjoiNjEzZTkwZjMtZjNjZS00MWY5LWE5ODgtMTIzNjg4M2M5Mjc3IiwiYWNyIjoiMCIsImFsbG93ZWQtb3JpZ2lucyI6WyIqIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI6WyJvZmZsaW5lX2FjY2VzcyIsImRlZmF1bHQtcm9sZXMtc3ZlbHRlLXRlc3QiLCJ1bWFfYXV0aG9yaXphdGlvbiIsImFsZ28iXX0sInJlc291cmNlX2FjY2VzcyI6eyJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJzY29wZSI6Im9wZW5pZCBwcm9maWxlIGVtYWlsIiwic2lkIjoiNjEzZTkwZjMtZjNjZS00MWY5LWE5ODgtMTIzNjg4M2M5Mjc3IiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJuYW1lIjoiRmlyc3QgTGFzdCIsInByZWZlcnJlZF91c2VybmFtZSI6InRlc3QiLCJnaXZlbl9uYW1lIjoiRmlyc3QiLCJmYW1pbHlfbmFtZSI6Ikxhc3QiLCJlbWFpbCI6InRlc3RAZnQudGVjaCJ9.TtEAnapPCWMR3u0rN8eFqGU-ecdJECzpJAnt9yIgNwUC3J-5g7VFpjpbNM6Ttzdmk_1s3kLc7Ai83U0P7YBjHodvsjexYJgiDStLfJT2L7GK1XBH2VS1G9_dBYJ-OchMHgWIKA94Bpi9rKWoP_b4YmWI511sCCSyZdbqa5lTdS57r5HkGZcDHll_1xjYvAoOMKF4_G0pL4pS9PVsDVD-fdshV1WNPaU60MpCJBFe2zaEx8lH_O0ExgRkkp5IA14eTanb0N5UI-fM843rSznre6udigpGHobk62oNKBaIriTlzTPDtzHr8rO1pAmRwDHMXYTcpPc0ukRghh4JHAzWNA"
``` 
Cheers! We successfully perform a DoS attack with an invalid token that comes from an unknown server.

This PR limit the lifetime of decoding keys to the creation of raw_claims.

Here is the code at fault:

- [acquired read lock before discovering](https://github.com/lpotthast/axum-keycloak-auth/blob/f5bf7e023919c6ae20a657874bd43267c706d0d6/src/service.rs#L123C1-L146C11)
```rust
    let decoding_keys = kc_instance.decoding_keys().await; // <----- Here acquires a lock with a prolonged lifetime
    let mut raw_claims = raw_token.decode(&header, expected_audiences, decoding_keys.iter());

    if raw_claims.is_err() {
        #[allow(clippy::unwrap_used)]
        let retry = match raw_claims.as_ref().unwrap_err() {
            AuthError::NoDecodingKeys | AuthError::Decode { source: _ } => {
                if kc_instance.discovery.is_pending() {
                    kc_instance.discovery.notified().await;
                } else {
                    kc_instance
                        .discovery
                        .dispatch(kc_instance.oidc_discovery_endpoint.clone()) // <---- write lock here
                        .await
                        .expect("No Join error");
                }
                true
            }
            _ => false,
        };
// read lock is not dropped yet
```
- [acquiring value lock will dead lock when oidc discovering](https://github.com/lpotthast/axum-keycloak-auth/blob/f5bf7e023919c6ae20a657874bd43267c706d0d6/src/action.rs#L98)
```rust
    pub(crate) fn dispatch(&self, action_input: I) -> JoinHandle<()> {
        let fut = (self.action_fn)(&action_input);
        // ...
        let value = self.value.clone();
        // ...

        tokio::spawn(async move {
            *input.write().await = Some(action_input.clone());
            // ...
            *value.write().await = Some(new_value);
            // ...
        })
    }
}
```