### PR TITLE
feat: allow custom extra fields for `KeycloakToken`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-keycloak-auth"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.74.1"
 authors = ["Lukas Potthast <privat@lukas-potthast.de>"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ pub async fn protected(Extension(token): Extension<KeycloakToken<Role>>) -> Resp
         StatusCode::OK,
         format!(
             "Hello {name} ({subject}). Your token is valid for another {valid_for} seconds.",
-            name = token.full_name,
+            name = token.extra.profile.preferred_username,
             subject = token.subject,
             valid_for = (token.expires_at - time::OffsetDateTime::now_utc()).whole_seconds()
         ),

--- a/src/action.rs
+++ b/src/action.rs
@@ -6,7 +6,11 @@ use std::{
 
 use educe::Educe;
 use futures::Future;
-use tokio::{sync::Notify, sync::{futures::Notified, RwLock}, task::JoinHandle};
+use tokio::{
+    sync::Notify,
+    sync::{futures::Notified, RwLock},
+    task::JoinHandle,
+};
 
 #[derive(Educe)]
 #[educe(Debug)]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,9 +1,7 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use http::HeaderMap;
 use http::HeaderValue;
-use serde::de::value::MapDeserializer;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, OneOrMany};
@@ -100,16 +98,6 @@ pub struct StandardClaims<Extra> {
 
     #[serde(flatten)]
     pub extra: Extra,
-}
-
-impl<Extra: DeserializeOwned> StandardClaims<Extra> {
-    pub fn parse(raw_claims: RawClaims) -> Result<Self, AuthError> {
-        Self::deserialize(MapDeserializer::new(raw_claims.into_iter())).map_err(|err| {
-            AuthError::JsonParse {
-                source: Arc::new(err),
-            }
-        })
-    }
 }
 
 /// Access details.

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use http::HeaderMap;
 use http::HeaderValue;
 use serde::de::value::MapDeserializer;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, OneOrMany};
 use snafu::ResultExt;
@@ -73,7 +74,7 @@ pub type RawClaims = HashMap<String, serde_json::Value>;
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StandardClaims {
+pub struct StandardClaims<Extra> {
     /// Expiration time (unix timestamp).
     pub exp: i64,
     /// Issued at time (unix timestamp).
@@ -96,21 +97,12 @@ pub struct StandardClaims {
     pub realm_access: Option<RealmAccess>,
     /// Keycloak: Optional client roles from Keycloak.
     pub resource_access: Option<ResourceAccess>,
-    /// Keycloak: First name.
-    pub given_name: String,
-    /// Keycloak: Last name.
-    pub family_name: String,
-    /// Keycloak: Combined name. Assume this to equal `format!("{given_name} {family name}")`.
-    pub name: String,
-    /// Keycloak: Username of the user.
-    pub preferred_username: String,
-    /// Keycloak: Email address of the user.
-    pub email: String,
-    /// Keycloak: Whether the users email is verified.
-    pub email_verified: bool,
+
+    #[serde(flatten)]
+    pub extra: Extra,
 }
 
-impl StandardClaims {
+impl<Extra: DeserializeOwned> StandardClaims<Extra> {
     pub fn parse(raw_claims: RawClaims) -> Result<Self, AuthError> {
         Self::deserialize(MapDeserializer::new(raw_claims.into_iter())).map_err(|err| {
             AuthError::JsonParse {
@@ -167,7 +159,11 @@ impl<R: Role> ExtractRoles<R> for ResourceAccess {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct KeycloakToken<R: Role> {
+pub struct KeycloakToken<R, Extra = ProfileAndEmail>
+where
+    R: Role,
+    Extra: DeserializeOwned + Clone,
+{
     /// Expiration time (UTC).
     pub expires_at: time::OffsetDateTime,
     /// Issued at time (UTC).
@@ -185,22 +181,16 @@ pub struct KeycloakToken<R: Role> {
 
     // Keycloak: Roles of the user.
     pub roles: Vec<KeycloakRole<R>>,
-    /// Keycloak: First name.
-    pub given_name: String,
-    /// Keycloak: Last name.
-    pub family_name: String,
-    /// Keycloak: Combined name. Assume this to equal `format!("{given_name} {family name}")`.
-    pub full_name: String,
-    /// Keycloak: Username of the user.
-    pub preferred_username: String,
-    /// Keycloak: Email address of the user.
-    pub email: String,
-    /// Keycloak: Whether the users email is verified.
-    pub email_verified: bool,
+
+    pub extra: Extra,
 }
 
-impl<R: Role> KeycloakToken<R> {
-    pub(crate) fn parse(raw: StandardClaims) -> Result<Self, AuthError> {
+impl<R, Extra> KeycloakToken<R, Extra>
+where
+    R: Role,
+    Extra: DeserializeOwned + Clone,
+{
+    pub(crate) fn parse(raw: StandardClaims<Extra>) -> Result<Self, AuthError> {
         Ok(Self {
             expires_at: time::OffsetDateTime::from_unix_timestamp(raw.exp).map_err(|err| {
                 AuthError::InvalidToken {
@@ -226,12 +216,7 @@ impl<R: Role> KeycloakToken<R> {
                 (raw.realm_access, raw.resource_access).extract_roles(&mut roles);
                 roles
             },
-            given_name: raw.given_name,
-            family_name: raw.family_name,
-            full_name: raw.name,
-            preferred_username: raw.preferred_username,
-            email_verified: raw.email_verified,
-            email: raw.email,
+            extra: raw.extra,
         })
     }
 
@@ -247,7 +232,11 @@ impl<R: Role> KeycloakToken<R> {
     }
 }
 
-impl<R: Role> ExpectRoles<R> for KeycloakToken<R> {
+impl<R, Extra> ExpectRoles<R> for KeycloakToken<R, Extra>
+where
+    R: Role,
+    Extra: DeserializeOwned + Clone,
+{
     type Rejection = AuthError;
 
     fn expect_roles<I: Into<R> + Clone>(&self, roles: &[I]) -> Result<(), Self::Rejection> {
@@ -271,4 +260,32 @@ impl<R: Role> ExpectRoles<R> for KeycloakToken<R> {
         }
         Ok(())
     }
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct Profile {
+    /// Keycloak: First name.
+    pub given_name: Option<String>,
+    /// Keycloak: Combined name. Assume this to equal `format!("{given_name} {family name}")`.
+    pub full_name: Option<String>,
+    /// Keycloak: Last name.
+    pub family_name: Option<String>,
+    /// Keycloak: Username of the user.
+    pub preferred_username: String,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct Email {
+    /// Keycloak: Email address of the user.
+    pub email: String,
+    /// Keycloak: Whether the users email is verified.
+    pub email_verified: bool,
+}
+
+#[derive(serde::Deserialize, Debug, Clone)]
+pub struct ProfileAndEmail {
+    #[serde(flatten)]
+    pub profile: Profile,
+    #[serde(flatten)]
+    pub email: Email,
 }

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// See: https://openid.net/specs/openid-connect-discovery-1_0.html#WellKnownContents
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/oidc_discovery.rs
+++ b/src/oidc_discovery.rs
@@ -8,14 +8,10 @@ use snafu::{ResultExt, Snafu};
 #[derive(Debug, Clone, Snafu)]
 pub enum RequestError {
     #[snafu(display("RequestError: Could not send request"))]
-    Send {
-        source: Arc<reqwest::Error>,
-    },
+    Send { source: Arc<reqwest::Error> },
 
     #[snafu(display("RequestError: Could not decode payload"))]
-    Decode {
-        source: Arc<reqwest::Error>,
-    },
+    Decode { source: Arc<reqwest::Error> },
 }
 
 pub(crate) async fn retrieve_oidc_config(


### PR DESCRIPTION
The should fix #7 and furthurmore provides ability to define custom jwt scopes/fields.

The previous version hard coded first_name, last_name, email and etc into `KeycloakToken`. But these tokens can actually be turned off, especially when configured with external identity services. 
<img width="1917" alt="image" src="https://github.com/lpotthast/axum-keycloak-auth/assets/16273287/c8d1d45b-4038-474e-8970-3a1975cfbcdc">

This PR add a generic parameter named `Extra` and passes it all the way through into KeycloakToken. Also, `ProfileAndEmail` is provided as the default `Extra` generic type, to meet the needs of most keycloak user that sticks with default usage (username/email/password authentication and never border to turned off profile or email scope).

I bump the version in Cargo.toml to 0.5.0, since this commit introduces some breaking API changes. There is no more `token.full_name` but `token.extra.profile.preferred_username` when `Extra` is set to `ProfileAndEmail`, which is the default generic type.

Here is an example to define and use custom jwt extra scopes:
```rust
// my tailored jwt scopes/fileds
#[derive(Deserialize, Clone)]
struct MyExtra {
    pub email: String,
    pub preferred_username: String,
    pub foo: String
}

pub async fn protected(Extension(token): Extension<KeycloakToken<String, MyExtra>>) -> Response {
    (StatusCode::OK,format!("Hello {}", token.extra.foo)).into_response()
}

let router = Router::new().route("/protected", get(protected)).layer(
        KeycloakAuthLayer::<String, MyExtra>::builder()
            .instance(instance)
            .passthrough_mode(PassthroughMode::Block)
            .persist_raw_claims(false)
            .expected_audiences(vec![])
            .required_roles(vec![])
            .build(),
);
```