### PR TITLE
oidc-discovery: allow user to specify retry strategy

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -89,6 +89,7 @@ mod test {
             KeycloakConfig::builder()
                 .server(Url::parse("https://localhost:8443/").unwrap())
                 .realm(String::from("MyRealm"))
+                .retry((10, 2))
                 .build(),
         );
 
@@ -105,6 +106,7 @@ mod test {
             KeycloakConfig::builder()
                 .server(Url::parse("https://localhost:8443/").unwrap())
                 .realm(String::from("MyRealm"))
+                .retry((10, 2))
                 .build(),
         );
 


### PR DESCRIPTION
We set a default value that resolves to the
previously hardcoded behavior, thus not breaking
any clients.

Closes #10.