### PR TITLE
Allow to configure where the auth token will be passed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ jsonwebtoken = "9"
 reqwest = { version = "0.12", features = ["json"], default-features = false }
 serde = "1"
 serde_json = "1"
+serde-querystring = "0.2.1"
 serde_with = "3"
 snafu = "0.8"
 time = "0.3"
@@ -30,7 +31,7 @@ tower = "0.4"
 tracing = "0.1"
 try-again = "0.1"
 typed-builder = "0.18"
-url = "2"
+url = "2.5.0"
 uuid = { version = "1", features = ["v7"] }
 
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,10 @@ pub enum AuthError {
     #[snafu(display("The 'Authorization' header was not present on a request."))]
     MissingAuthorizationHeader,
 
+    /// The 'Authorization' query parameter was not present on a request.
+    #[snafu(display("The 'Authorization' query parameter was not present on a request."))]
+    MissingAuthorizationQuery,
+
     /// The 'Authorization' header was present on a request but its value could not be parsed.
     /// This can occur if the header value did not solely contain visible ASCII characters.
     #[snafu(display("The 'Authorization' header was present on a request but its value could not be parsed. Reason: {reason}"))]
@@ -118,6 +122,9 @@ impl IntoResponse for AuthError {
                 Cow::Owned(err.to_string()),
             ),
             err @ AuthError::MissingAuthorizationHeader => {
+                (StatusCode::UNAUTHORIZED, Cow::Owned(err.to_string()))
+            }
+            err @ AuthError::MissingAuthorizationQuery => {
                 (StatusCode::UNAUTHORIZED, Cow::Owned(err.to_string()))
             }
             err @ AuthError::InvalidAuthorizationHeader { reason: _ } => {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -7,6 +7,7 @@ use typed_builder::TypedBuilder;
 
 use crate::decode::{validate_raw_token, KeycloakToken, ProfileAndEmail, RawToken};
 use crate::error::AuthError;
+use crate::TokenSource;
 use crate::{instance::KeycloakAuthInstance, role::Role, service::KeycloakAuthService};
 
 use super::PassthroughMode;
@@ -41,6 +42,10 @@ where
     /// leave this empty and perform manuakl role checks in your route handlers.
     #[builder(default = vec![], setter(into))]
     pub required_roles: Vec<R>,
+
+    /// Specifies where the token is expected to be found.
+    #[builder(default = TokenSource::Header, setter(into))]
+    pub token_source: TokenSource,
 
     #[builder(default = uuid::Uuid::now_v7(), setter(skip))]
     id: uuid::Uuid,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,21 @@ pub enum PassthroughMode {
     Pass,
 }
 
+/// The mode describes where the middleware looks for the jwt access token.
+///
+/// ```TokenSource::Header```: The bearer token is in the authorization header. (Authorization: Bearer <token>)
+///
+/// ```TokenSource::Query```:  The auth token is in the query parameter of the url. (http://<url>/<path>?token=<token>)
+///
+/// ```TokenSource::Both```:   Assumes the token is in the header, but also checks the query parameter if the header is missing.
+///
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum TokenSource {
+    Header,
+    Query,
+    Both,
+}
+
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum KeycloakAuthStatus<R, Extra>


### PR DESCRIPTION
### Description

When using the WebSocket implementation in JavaScript, it can be challenging to add an Authorization header. For more context, see [solution 3 by kaqqao on Stack Overflow](https://stackoverflow.com/questions/4361173/http-headers-in-websockets-client-api).

This pull request introduces a way to configure the middleware, allowing you to specify where the JWT token should be expected. The token can be placed in the **HEADER** (default), **QUERY PARAM**, or **BOTH** (this solution first checks the header and if there is no token, it then checks the query param).

### Changes

- Added configuration options to the middleware for specifying the JWT token location:
  - **HEADER** (default)
  - **QUERY PARAM**
  - **BOTH**

This enhancement provides flexibility in managing WebSocket authentication, making it easier to adapt to different client implementations and security requirements.

