### PR TITLE
Cargo.toml: bump serde-querystring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ jsonwebtoken = "9.3.0"
 nonempty = { version = "0.11.0", features = ["std"] }
 reqwest = { version = "0.12.12", features = ["json"], default-features = false }
 serde = "1.0.217"
-serde-querystring = "0.2.1"
+serde-querystring = "0.3.0"
 serde_json = "1.0.134"
 serde_with = "3.12.0"
 snafu = "0.8.5"


### PR DESCRIPTION
The previous version depended on the unmaintained
`lexical` crate [1].

[1] https://github.com/pooyamb/serde-querystring/blob/main/CHANGES.md#030-beta0---2024-08-08