### PR TITLE
feat: discriminate role based permission control for realm roles and resource roles

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ use serde_json::json;
 use snafu::Snafu;
 
 use crate::oidc_discovery;
+use crate::role::KeycloakRole;
 
 #[derive(Debug, Clone, Snafu)]
 #[snafu(visibility(pub(crate)))]
@@ -105,7 +106,7 @@ pub enum AuthError {
 
     /// Note: The `IntoResponse` implementation will only show the provided role in a debug build!
     #[snafu(display("An expected role (omitted for security reasons) was missing."))]
-    MissingExpectedRole { role: String },
+    MissingExpectedRole { role: KeycloakRole<String> },
 
     /// An unexpected role was present.
     #[snafu(display("An unexpected role was present."))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! ```rust
 //! use std::sync::Arc;
 //! use axum::{http::StatusCode, response::{Response, IntoResponse}, routing::get, Extension, Router};
-//! use axum_keycloak_auth::{Url, error::AuthError, instance::KeycloakConfig, instance::KeycloakAuthInstance, layer::KeycloakAuthLayer, decode::KeycloakToken, PassthroughMode, expect_role};
+//! use axum_keycloak_auth::{Url, error::AuthError, instance::KeycloakConfig, instance::KeycloakAuthInstance, layer::KeycloakAuthLayer, decode::KeycloakToken, PassthroughMode, expect_role, role::KeycloakRole};
 //!
 //! pub fn public_router() -> Router {
 //!     Router::new()
@@ -27,7 +27,7 @@
 //! }
 //!
 //! pub fn protected_router(instance: KeycloakAuthInstance) -> Router {
-//!     Router::new()
+//! Router::new()
 //!         .route("/protected", get(protected))
 //!         .layer(
 //!              KeycloakAuthLayer::<String>::builder()
@@ -35,7 +35,9 @@
 //!                  .passthrough_mode(PassthroughMode::Block)
 //!                  .persist_raw_claims(false)
 //!                  .expected_audiences(vec![String::from("account")])
-//!                  .required_roles(vec![String::from("administrator")])
+//!                  .required_roles(vec![KeycloakRole::Realm {
+//!                role: String::from("administrator"),
+//!            }])
 //!                  .build(),
 //!         )
 //! }
@@ -49,13 +51,15 @@
 //!
 //! #[allow(dead_code)]
 //! pub fn protect(router:Router, instance: Arc<KeycloakAuthInstance>) -> Router {
-//!     router.layer(
+//! router.layer(
 //!         KeycloakAuthLayer::<String>::builder()
 //!             .instance(instance)
 //!             .passthrough_mode(PassthroughMode::Block)
 //!             .persist_raw_claims(false)
 //!             .expected_audiences(vec![String::from("account")])
-//!             .required_roles(vec![String::from("administrator")])
+//!             .required_roles(vec![KeycloakRole::Realm {
+//!                role: String::from("administrator"),
+//!            }])
 //!             .build(),
 //!     )
 //! }
@@ -77,7 +81,7 @@
 //! }
 //!
 //! pub async fn protected(Extension(token): Extension<KeycloakToken<String>>) -> Response {
-//!     expect_role!(&token, "administrator");
+//!     expect_role!(&token, KeycloakRole::Realm { role: "administrator".into() });
 //!
 //!     tracing::info!("Token payload is {token:#?}");
 //!
@@ -156,8 +160,10 @@
 //! use axum::{http::StatusCode, response::{Response, IntoResponse}, Extension};
 //! use axum_keycloak_auth::{decode::KeycloakToken, expect_role};
 //!
+//! use axum_keycloak_auth::role::KeycloakRole;
+//!
 //! pub async fn protected(Extension(token): Extension<KeycloakToken<Role>>) -> Response {
-//!     expect_role!(&token, Role::Administrator);
+//!     expect_role!(&token, KeycloakRole::Realm {role: Role::Administrator});
 //!     StatusCode::OK.into_response()
 //! }
 //! ```

--- a/src/role.rs
+++ b/src/role.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Debug, Display};
+use std::fmt::{Debug, Display, Formatter};
 
 use axum::response::IntoResponse;
 use serde::{Deserialize, Serialize};
@@ -26,6 +26,16 @@ pub enum KeycloakRole<R: Role> {
         /// Name of the role
         role: R,
     },
+}
+impl<R: Role> Display for KeycloakRole<R> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KeycloakRole::Realm { role } => f.write_fmt(format_args!("Realm: {}", role)),
+            KeycloakRole::Client { client, role } => {
+                f.write_fmt(format_args!("Client({}): {}", client, role))
+            }
+        }
+    }
 }
 
 impl<R: Role> KeycloakRole<R> {
@@ -78,8 +88,8 @@ where
 pub trait ExpectRoles<R: Role> {
     type Rejection: IntoResponse;
 
-    fn expect_roles<I: Into<R> + Clone>(&self, roles: &[I]) -> Result<(), Self::Rejection>;
-    fn not_expect_roles<I: Into<R> + Clone>(&self, roles: &[I]) -> Result<(), Self::Rejection>;
+    fn expect_roles(&self, roles: &[KeycloakRole<R>]) -> Result<(), Self::Rejection>;
+    fn not_expect_roles(&self, roles: &[KeycloakRole<R>]) -> Result<(), Self::Rejection>;
 }
 
 #[macro_export]


### PR DESCRIPTION
The current implementation merge realm roles and resource roles into one vector, and check against role regardless it's realm role or resources roles. This implementation can cause unintentional permission leakage. 

For example, say we have two resource scope named `client-a` and `client-b`, and there is a `member` role in both resource scope. The current implementation will allow user access as long as user have the `member` role in either scope. In other words, a user with only `member` role in `client-a` is regarded as valid user in `client-b` too.

This PR allow users to specify the expected role is realm role or resource role of specific client/scope.