### PR TITLE
make email field in jwt token Optional

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -372,7 +372,7 @@ pub struct Profile {
 #[derive(serde::Deserialize, Debug, Clone)]
 pub struct Email {
     /// Keycloak: Email address of the user.
-    pub email: String,
+    pub email: Option<String>,
     /// Keycloak: Whether the users email is verified.
     pub email_verified: bool,
 }


### PR DESCRIPTION
The email field of the JWT Token issued by Keycloak should be optional. In this way, we can also support tokens that are not issued on a User Level because they won't include the email property by design