### PR TITLE
feat: Allow configuration of request timeouts

### DIFF
--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{ops::Deref, time::Duration};
 
 use educe::Educe;
 use snafu::ResultExt;
@@ -47,6 +47,9 @@ pub struct KeycloakConfig {
     /// The retry strategy to be used: (maximum tries, delay in seconds).
     #[builder(default = (5, 1))]
     pub retry: (usize, u64),
+
+    #[builder(default = None)]
+    pub timeout: Option<Duration>,
 }
 
 fn debug_decoding_keys(
@@ -115,6 +118,7 @@ impl KeycloakAuthInstance {
                     oidc_discovery_endpoint,
                     kc_config.retry.0,
                     std::time::Duration::from_secs(kc_config.retry.1),
+                    kc_config.timeout,
                 )
                 .instrument(span)
                 .await
@@ -181,14 +185,27 @@ async fn perform_oidc_discovery(
     oidc_discovery_endpoint: OidcDiscoveryEndpoint,
     num_retries: usize,
     fixed_delay: StdDuration,
+    timeout: Option<Duration>,
 ) -> Result<DiscoveredData, AuthError> {
     tracing::info!("Starting OIDC discovery.");
 
+    // Configure HTTP client
+    let http_client = {
+        let mut builder = reqwest::Client::builder();
+        if let Some(timeout) = timeout {
+            builder = builder.timeout(timeout);
+        }
+        builder.build().expect("build HTTP client")
+    };
+
     // Load OIDC config.
-    let oidc_config = retry_async(async move || {
-        oidc_discovery::retrieve_oidc_config(oidc_discovery_endpoint.0.clone())
-            .await
-            .context(OidcDiscoverySnafu {})
+    let oidc_config = retry_async({
+        let http_client = http_client.clone();
+        async move || {
+            oidc_discovery::retrieve_oidc_config(&http_client, oidc_discovery_endpoint.0.clone())
+                .await
+                .context(OidcDiscoverySnafu {})
+        }
     })
     .delayed_by(delay::Fixed::of(fixed_delay).take(num_retries))
     .await
@@ -210,10 +227,13 @@ async fn perform_oidc_discovery(
         })?;
 
     // Load JWK set if endpoint was parsable.
-    let jwk_set = retry_async(async move || {
-        oidc_discovery::retrieve_jwk_set(jwk_set_endpoint.clone())
-            .await
-            .context(JwkSetDiscoverySnafu {})
+    let jwk_set = retry_async({
+        let http_client = http_client.clone();
+        async move || {
+            oidc_discovery::retrieve_jwk_set(&http_client, jwk_set_endpoint.clone())
+                .await
+                .context(JwkSetDiscoverySnafu {})
+        }
     })
     .delayed_by(delay::Fixed::of(fixed_delay).take(num_retries))
     .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 //!
 //! ```rust
 //! use std::sync::Arc;
+//! use std::time::Duration;
 //! use axum::{http::StatusCode, response::{Response, IntoResponse}, routing::get, Extension, Router};
 //! use axum_keycloak_auth::{Url, error::AuthError, instance::KeycloakConfig, instance::KeycloakAuthInstance, layer::KeycloakAuthLayer, decode::KeycloakToken, PassthroughMode, expect_role};
 //!
@@ -103,6 +104,7 @@
 //!         KeycloakConfig::builder()
 //!             .server(Url::parse("https://localhost:8443/").unwrap())
 //!             .realm(String::from("MyRealm"))
+//!             .timeout(Some(Duration::from_secs(5)))
 //!             .build(),
 //!     );
 //!     let router = public_router().merge(protected_router(keycloak_auth_instance));

--- a/src/oidc_discovery.rs
+++ b/src/oidc_discovery.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::oidc::OidcConfig;
-use reqwest::IntoUrl;
+use reqwest::{Client, IntoUrl};
 use serde::Deserialize;
 use snafu::{ResultExt, Snafu};
 
@@ -15,9 +15,10 @@ pub enum RequestError {
 }
 
 pub(crate) async fn retrieve_oidc_config(
+    http_client: &Client,
     discovery_endpoint: impl IntoUrl,
 ) -> Result<OidcConfig, RequestError> {
-    reqwest::Client::new()
+    http_client
         .get(discovery_endpoint)
         .send()
         .await
@@ -30,13 +31,14 @@ pub(crate) async fn retrieve_oidc_config(
 }
 
 pub(crate) async fn retrieve_jwk_set(
+    http_client: &Client,
     jwk_set_endpoint: impl IntoUrl,
 ) -> Result<jsonwebtoken::jwk::JwkSet, RequestError> {
     #[derive(Deserialize)]
     pub struct RawJwkSet {
         pub keys: Vec<serde_json::Value>,
     }
-    let raw_set = reqwest::Client::new()
+    let raw_set = http_client
         .get(jwk_set_endpoint)
         .send()
         .await


### PR DESCRIPTION
This pull request allows users of this library to configure a timeout when calling out to Keycloak (during OIDC discovery and when updating JWK sets).