### PR TITLE
parameterize the type of the sub token, making it a uuid::Uuid by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "axum-keycloak-auth"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "assertr",
  "atomic-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-keycloak-auth"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85.0"
 authors = ["Lukas Potthast <privat@lukas-potthast.de>"]
@@ -39,7 +39,7 @@ tracing = "0.1.41"
 try-again = "0.2.0"
 typed-builder = "0.21.0"
 url = "2.5.4"
-uuid = { version = "1.11.0", features = ["v7"] }
+uuid = { version = "1.11.0", features = ["v7", "serde"] }
 
 [dev-dependencies]
 axum = { version = "0.8.4", features = ["macros"] }

--- a/src/action.rs
+++ b/src/action.rs
@@ -3,8 +3,8 @@ use std::{
     option::Option,
     pin::Pin,
     sync::{
-        atomic::{AtomicBool, AtomicUsize},
         Arc,
+        atomic::{AtomicBool, AtomicUsize},
     },
 };
 
@@ -13,7 +13,7 @@ use educe::Educe;
 use futures::Future;
 use tokio::{
     sync::Notify,
-    sync::{futures::Notified, RwLock},
+    sync::{RwLock, futures::Notified},
     task::JoinHandle,
 };
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
-use jsonwebtoken::errors::ErrorKind;
 use jsonwebtoken::Header;
+use jsonwebtoken::errors::ErrorKind;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, OneOrMany};
+use serde_with::{OneOrMany, serde_as};
 use snafu::ResultExt;
 use tracing::debug;
+use uuid::Uuid;
 
 use crate::error::DecodeHeaderSnafu;
 use crate::error::DecodeSnafu;
@@ -111,19 +112,21 @@ pub(crate) async fn decode_and_validate(
     raw_claims
 }
 
-pub(crate) async fn parse_raw_claims<R, Extra>(
+pub(crate) async fn parse_raw_claims<R, Sub, Extra>(
     raw_claims: RawClaims,
     persist_raw_claims: bool,
     required_roles: &[R],
 ) -> Result<
     (
         Option<HashMap<String, serde_json::Value>>,
-        KeycloakToken<R, Extra>,
+        KeycloakToken<R, Sub, Extra>,
     ),
     AuthError,
 >
 where
     R: Role,
+    Sub: FromStr,
+    Sub::Err: Into<AuthError>,
     Extra: DeserializeOwned + Clone,
 {
     let raw_claims_clone = match persist_raw_claims {
@@ -135,7 +138,7 @@ where
     let standard_claims = serde_json::from_value(value).map_err(|err| AuthError::JsonParse {
         source: Arc::new(err),
     })?;
-    let keycloak_token = KeycloakToken::<R, Extra>::parse(standard_claims)?;
+    let keycloak_token = KeycloakToken::<R, Sub, Extra>::parse(standard_claims)?;
     keycloak_token.assert_not_expired()?;
     keycloak_token.expect_roles(required_roles)?;
     Ok((raw_claims_clone, keycloak_token))
@@ -254,7 +257,7 @@ impl<R: Role> ExtractRoles<R> for ResourceAccess {
 /// }
 /// ```
 #[derive(Debug, PartialEq, Clone)]
-pub struct KeycloakToken<R, Extra = ProfileAndEmail>
+pub struct KeycloakToken<R, Sub = Uuid, Extra = ProfileAndEmail>
 where
     R: Role,
     Extra: DeserializeOwned + Clone,
@@ -270,7 +273,7 @@ where
     /// Audience (who or what the token is intended for).
     pub audience: Vec<String>,
     /// Subject (whom the token refers to). This is the UUID which uniquely identifies this user inside Keycloak.
-    pub subject: String,
+    pub subject: Sub,
     /// Authorized party (the party to which this token was issued).
     pub authorized_party: String,
 
@@ -280,9 +283,11 @@ where
     pub extra: Extra,
 }
 
-impl<R, Extra> KeycloakToken<R, Extra>
+impl<R, Sub, Extra> KeycloakToken<R, Sub, Extra>
 where
     R: Role,
+    Sub: FromStr,
+    Sub::Err: Into<AuthError>,
     Extra: DeserializeOwned + Clone,
 {
     pub(crate) fn parse(raw: StandardClaims<Extra>) -> Result<Self, AuthError> {
@@ -304,7 +309,7 @@ where
             jwt_id: raw.jti,
             issuer: raw.iss,
             audience: raw.aud,
-            subject: raw.sub,
+            subject: raw.sub.parse().map_err(Into::into)?,
             authorized_party: raw.azp,
             roles: {
                 let mut roles = Vec::new();
@@ -327,7 +332,7 @@ where
     }
 }
 
-impl<R, Extra> ExpectRoles<R> for KeycloakToken<R, Extra>
+impl<R, Sub, Extra> ExpectRoles<R> for KeycloakToken<R, Sub, Extra>
 where
     R: Role,
     Extra: DeserializeOwned + Clone,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
 use std::{borrow::Cow, sync::Arc};
 
 use axum::{
+    Json,
     http::StatusCode,
     response::{IntoResponse, Response},
-    Json,
 };
 use serde_json::json;
 use snafu::Snafu;
@@ -44,7 +44,9 @@ pub enum AuthError {
 
     /// The 'Authorization' header was present on a request but its value could not be parsed.
     /// This can occur if the header value did not solely contain visible ASCII characters.
-    #[snafu(display("The 'Authorization' header was present on a request but its value could not be parsed. Reason: {reason}"))]
+    #[snafu(display(
+        "The 'Authorization' header was present on a request but its value could not be parsed. Reason: {reason}"
+    ))]
     InvalidAuthorizationHeader { reason: String },
 
     /// The 'Authorization' header was present  and could be parsed, but it did not contain the expected "Bearer {token}" format.
@@ -64,7 +66,9 @@ pub enum AuthError {
     MissingTokenQueryParam,
 
     /// Query parameters were found on the request, and the expected token parameter was found, but it had no value assigned ("?token=").
-    #[snafu(display("Query parameters were found on the request, and the expected token parameter was found, but it had no value assigned (\"?token=\")."))]
+    #[snafu(display(
+        "Query parameters were found on the request, and the expected token parameter was found, but it had no value assigned (\"?token=\")."
+    ))]
     EmptyTokenQueryParam,
 
     /// No JWT could be extracted from the request.
@@ -110,6 +114,14 @@ pub enum AuthError {
     /// An unexpected role was present.
     #[snafu(display("An unexpected role was present."))]
     UnexpectedRole,
+}
+
+impl From<uuid::Error> for AuthError {
+    fn from(err: uuid::Error) -> Self {
+        AuthError::InvalidToken {
+            reason: format!("failed to parse parse uuid: {err}"),
+        }
+    }
 }
 
 impl IntoResponse for AuthError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -124,6 +124,12 @@ impl From<uuid::Error> for AuthError {
     }
 }
 
+impl From<std::convert::Infallible> for AuthError {
+    fn from(infallible: std::convert::Infallible) -> Self {
+        match infallible {}
+    }
+}
+
 impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
         let (status, error_message) = match self {

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -2,12 +2,12 @@ use nonempty::NonEmpty;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, str::FromStr, sync::Arc};
 use tower::Layer;
 use typed_builder::TypedBuilder;
 
 use crate::decode::{
-    decode_and_validate, parse_raw_claims, KeycloakToken, ProfileAndEmail, RawToken,
+    KeycloakToken, ProfileAndEmail, RawToken, decode_and_validate, parse_raw_claims,
 };
 use crate::error::AuthError;
 use crate::extract::TokenExtractor;
@@ -20,11 +20,11 @@ extern crate alloc;
 /// Add this layer to a router to protect the contained route handlers.
 /// Authentication happens by looking for the `Authorization` header on requests and parsing the contained JWT bearer token.
 /// See the crate level documentation for how this layer can be created and used.
-#[derive(Clone, TypedBuilder)]
-pub struct KeycloakAuthLayer<R, Extra = ProfileAndEmail>
+#[derive(TypedBuilder)]
+pub struct KeycloakAuthLayer<R, Sub = uuid::Uuid, Extra = ProfileAndEmail>
 where
     R: Role,
-    Extra: DeserializeOwned + Clone,
+    Extra: DeserializeOwned,
 {
     #[builder(setter(into))]
     pub instance: Arc<KeycloakAuthInstance>,
@@ -57,11 +57,37 @@ where
 
     #[builder(default=PhantomData, setter(skip))]
     phantom: PhantomData<Extra>,
+
+    #[builder(default=PhantomData, setter(skip))]
+    phantom_subject_type: PhantomData<Sub>,
 }
 
-impl<R, Extra> KeycloakAuthLayer<R, Extra>
+// Manually implement Clone so we can avoid a `Clone` bound on `Sub` and `Extra`
+impl<R, Sub, Extra> Clone for KeycloakAuthLayer<R, Sub, Extra>
 where
     R: Role,
+    Extra: DeserializeOwned,
+{
+    fn clone(&self) -> Self {
+        Self {
+            instance: self.instance.clone(),
+            passthrough_mode: self.passthrough_mode,
+            persist_raw_claims: self.persist_raw_claims,
+            expected_audiences: self.expected_audiences.clone(),
+            required_roles: self.required_roles.clone(),
+            token_extractors: self.token_extractors.clone(),
+            id: self.id,
+            phantom: PhantomData,
+            phantom_subject_type: PhantomData,
+        }
+    }
+}
+
+impl<R, Sub, Extra> KeycloakAuthLayer<R, Sub, Extra>
+where
+    R: Role,
+    Sub: FromStr,
+    Sub::Err: Into<AuthError>,
     Extra: DeserializeOwned + Clone,
 {
     /// Allows to validate a raw keycloak token given as &str (without the "Bearer " part when taken from an authorization header).
@@ -73,7 +99,7 @@ where
     ) -> Result<
         (
             Option<HashMap<String, serde_json::Value>>,
-            KeycloakToken<R, Extra>,
+            KeycloakToken<R, Sub, Extra>,
         ),
         AuthError,
     > {
@@ -84,12 +110,12 @@ where
         )
         .await?;
 
-        parse_raw_claims::<R, Extra>(raw_claims, self.persist_raw_claims, &self.required_roles)
+        parse_raw_claims::<R, Sub, Extra>(raw_claims, self.persist_raw_claims, &self.required_roles)
             .await
     }
 }
 
-impl<R, Extra> Debug for KeycloakAuthLayer<R, Extra>
+impl<R, Sub, Extra> Debug for KeycloakAuthLayer<R, Sub, Extra>
 where
     R: Role,
     Extra: DeserializeOwned + Clone,
@@ -102,12 +128,12 @@ where
     }
 }
 
-impl<S, R, Extra> Layer<S> for KeycloakAuthLayer<R, Extra>
+impl<S, R, Sub, Extra> Layer<S> for KeycloakAuthLayer<R, Sub, Extra>
 where
     R: Role,
     Extra: DeserializeOwned + Clone,
 {
-    type Service = KeycloakAuthService<S, R, Extra>;
+    type Service = KeycloakAuthService<S, R, Sub, Extra>;
 
     #[tracing::instrument(level="info", skip_all, fields(id = ?self.id))]
     fn layer(&self, inner: S) -> Self::Service {
@@ -123,10 +149,10 @@ mod test {
     use url::Url;
 
     use crate::{
+        PassthroughMode,
         extract::{AuthHeaderTokenExtractor, QueryParamTokenExtractor, TokenExtractor},
         instance::{KeycloakAuthInstance, KeycloakConfig},
         layer::KeycloakAuthLayer,
-        PassthroughMode,
     };
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,12 +258,12 @@ pub enum PassthroughMode {
 
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
-pub enum KeycloakAuthStatus<R, Extra>
+pub enum KeycloakAuthStatus<R, Sub, Extra>
 where
     R: Role,
     Extra: DeserializeOwned + Clone,
 {
     // This variant is fairly large, but probably used most of the time. Leaving this non-boxed results in one less allocation each request.
-    Success(decode::KeycloakToken<R, Extra>),
+    Success(decode::KeycloakToken<R, Sub, Extra>),
     Failure(Arc<error::AuthError>),
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,4 +1,5 @@
 use std::{
+    str::FromStr,
     sync::Arc,
     task::{Context, Poll},
 };
@@ -9,26 +10,26 @@ use http::Request;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    error::AuthError, extract, layer::KeycloakAuthLayer, role::Role, KeycloakAuthStatus,
-    PassthroughMode,
+    KeycloakAuthStatus, PassthroughMode, error::AuthError, extract, layer::KeycloakAuthLayer,
+    role::Role,
 };
 
 #[derive(Clone)]
-pub struct KeycloakAuthService<S, R, Extra>
+pub struct KeycloakAuthService<S, R, Sub, Extra>
 where
     R: Role,
     Extra: DeserializeOwned + Clone,
 {
     inner: S,
-    layer: KeycloakAuthLayer<R, Extra>,
+    layer: KeycloakAuthLayer<R, Sub, Extra>,
 }
 
-impl<S, R, Extra> KeycloakAuthService<S, R, Extra>
+impl<S, R, Sub, Extra> KeycloakAuthService<S, R, Sub, Extra>
 where
     R: Role,
     Extra: DeserializeOwned + Clone,
 {
-    pub fn new(inner: S, layer: &KeycloakAuthLayer<R, Extra>) -> Self {
+    pub fn new(inner: S, layer: &KeycloakAuthLayer<R, Sub, Extra>) -> Self {
         Self {
             inner,
             layer: layer.clone(),
@@ -36,11 +37,13 @@ where
     }
 }
 
-impl<S, R, Extra> tower::Service<Request<Body>> for KeycloakAuthService<S, R, Extra>
+impl<S, R, Sub, Extra> tower::Service<Request<Body>> for KeycloakAuthService<S, R, Sub, Extra>
 where
     S: tower::Service<Request<Body>, Response = axum::response::Response> + Clone + Send + 'static,
     S::Future: Send + 'static,
     R: Role + 'static,
+    Sub: FromStr + Clone + Send + Sync + 'static,
+    Sub::Err: Into<AuthError>,
     Extra: DeserializeOwned + Clone + Sync + Send + 'static,
 {
     type Response = S::Response;
@@ -103,9 +106,9 @@ where
                             request.extensions_mut().insert(keycloak_token);
                         }
                         PassthroughMode::Pass => {
-                            request
-                                .extensions_mut()
-                                .insert(KeycloakAuthStatus::<R, Extra>::Success(keycloak_token));
+                            request.extensions_mut().insert(
+                                KeycloakAuthStatus::<R, Sub, Extra>::Success(keycloak_token),
+                            );
                         }
                     };
                     inner.call(request).await
@@ -115,7 +118,7 @@ where
                     PassthroughMode::Pass => {
                         request
                             .extensions_mut()
-                            .insert(KeycloakAuthStatus::<R, Extra>::Failure(Arc::new(err)));
+                            .insert(KeycloakAuthStatus::<R, Sub, Extra>::Failure(Arc::new(err)));
                         inner.call(request).await
                     }
                 },

--- a/tests/backend/mod.rs
+++ b/tests/backend/mod.rs
@@ -1,13 +1,13 @@
 use axum::{
-    response::{IntoResponse, Response}, routing::get, Extension,
-    Json,
-    Router,
+    Extension, Json, Router,
+    response::{IntoResponse, Response},
+    routing::get,
 };
 use axum_keycloak_auth::{
-    decode::KeycloakToken, instance::{KeycloakAuthInstance, KeycloakConfig},
+    KeycloakAuthStatus, PassthroughMode,
+    decode::KeycloakToken,
+    instance::{KeycloakAuthInstance, KeycloakConfig},
     layer::KeycloakAuthLayer,
-    KeycloakAuthStatus,
-    PassthroughMode,
 };
 use http::StatusCode;
 use serde::Serialize;

--- a/tests/common/tracing.rs
+++ b/tests/common/tracing.rs
@@ -1,5 +1,5 @@
 use tracing_subscriber::{
-    prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, Layer,
+    Layer, prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt,
 };
 
 pub fn init_subscriber() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,11 +3,11 @@ use std::time::Duration;
 use assertr::prelude::*;
 use http::StatusCode;
 use keycloak::{
+    KeycloakAdmin,
     types::{
         ClientRepresentation, CredentialRepresentation, RealmRepresentation, RoleRepresentation,
         RolesRepresentation, UserRepresentation,
     },
-    KeycloakAdmin,
 };
 use reqwest::Client;
 

--- a/tests/keycloak_container/mod.rs
+++ b/tests/keycloak_container/mod.rs
@@ -1,8 +1,8 @@
 use keycloak::{KeycloakAdmin, KeycloakAdminToken, KeycloakTokenSupplier};
 use testcontainers::{
-    core::{ContainerPort, WaitFor}, runners::AsyncRunner,
-    GenericImage,
-    ImageExt,
+    GenericImage, ImageExt,
+    core::{ContainerPort, WaitFor},
+    runners::AsyncRunner,
 };
 use url::Url;
 


### PR DESCRIPTION
parameterize the type of the sub token, making it a uuid::Uuid by default, but allowing for types that implement `FromStr`, including String. This helps move repetitive parsing logic out of handlers, ie parsing the string `sub` to a UUID at the top of every handler.
    
Run `cargo fmt` for formatting.